### PR TITLE
refactor: API-Aufruf und Response-Verarbeitung in UnpaywallService trennen

### DIFF
--- a/app/Services/UnpaywallService.php
+++ b/app/Services/UnpaywallService.php
@@ -23,6 +23,32 @@ class UnpaywallService
      */
     public function resolveOaUrl(string $doi): ?string
     {
+        $data = $this->fetchFromUnpaywall($doi);
+
+        if ($data === null) {
+            return null;
+        }
+
+        $url = data_get($data, 'best_oa_location.url_for_pdf');
+
+        if (blank($url)) {
+            Log::info('No Open Access URL found in Unpaywall', [
+                'doi' => $doi,
+            ]);
+            return null;
+        }
+
+        return $url;
+    }
+
+    /**
+     * Fetch raw response data from the Unpaywall API.
+     *
+     * @param string $doi The Digital Object Identifier
+     * @return ?array The decoded JSON response, or null on failure
+     */
+    private function fetchFromUnpaywall(string $doi): ?array
+    {
         $email = config('mail.from.address', 'info@linn.games');
 
         try {
@@ -39,16 +65,7 @@ class UnpaywallService
                 return null;
             }
 
-            $url = $response->json('best_oa_location.url_for_pdf');
-
-            if (blank($url)) {
-                Log::info('No Open Access URL found in Unpaywall', [
-                    'doi' => $doi,
-                ]);
-                return null;
-            }
-
-            return $url;
+            return $response->json();
         } catch (\Throwable $e) {
             Log::error('Unpaywall API error', [
                 'doi'     => $doi,


### PR DESCRIPTION
## Zusammenfassung

API-Aufruf und Response-Verarbeitung in `UnpaywallService.php` getrennt (Turbulenz-Score 53.3% → erwartet < 50%).

## Änderungen

- **`fetchFromUnpaywall()` extrahiert** (private): HTTP-Request, Timeout, Config-Zugriff (`mail.from.address`), Fehler-Logging bei 5xx und Netzwerkfehlern, gibt rohes JSON-Array oder `null` zurück
- **`resolveOaUrl()` vereinfacht**: Ruft nur noch `fetchFromUnpaywall()` auf, extrahiert `best_oa_location.url_for_pdf` via `data_get()`, loggt wenn keine URL gefunden

## Ergebnis

- 1 Datei geändert: +27 / -10 Zeilen
- Alle **5 Tests grün** mit 8 Assertions
- Tests brauchten **keine Änderung** (testen über `Http::fake()`)

Closes #62

## Summary by Sourcery

Refactor UnpaywallService to separate the Unpaywall API call from response processing while preserving existing behavior.

Enhancements:
- Extract a private fetchFromUnpaywall() method to handle HTTP requests, configuration access, and error logging, returning raw JSON or null.
- Simplify resolveOaUrl() to delegate API access to fetchFromUnpaywall() and focus solely on extracting and validating the Open Access PDF URL.