### PR TITLE
fix: Bearer-Token hashen im mcp-Limiter, webhooks-Limiter entfernen

### DIFF
--- a/app/Providers/RateLimitingServiceProvider.php
+++ b/app/Providers/RateLimitingServiceProvider.php
@@ -13,14 +13,12 @@ class RateLimitingServiceProvider extends ServiceProvider
     {
         RateLimiter::for('mcp', function (Request $request) {
             $limit = config('services.mcp.rate_limit', 60);
+            $token = $request->bearerToken();
+            $identifier = $token !== null && $token !== ''
+                ? hash('sha256', $token)
+                : $request->ip();
 
-            return Limit::perMinute($limit)->by($request->bearerToken() ?: $request->ip());
-        });
-
-        RateLimiter::for('webhooks', function (Request $request) {
-            $limit = config('services.webhooks.rate_limit', 30);
-
-            return Limit::perMinute($limit)->by($request->ip());
+            return Limit::perMinute($limit)->by($identifier);
         });
     }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -70,10 +70,6 @@ return [
         'rate_limit' => (int) env('MCP_RATE_LIMIT', 60),
     ],
 
-    'webhooks' => [
-        'rate_limit' => (int) env('WEBHOOKS_RATE_LIMIT', 30),
-    ],
-
     'ollama' => [
         'url' => env('OLLAMA_URL', 'http://localhost:11434'),
     ],


### PR DESCRIPTION
## Kontext

Adressiert Copilot-Review-Kommentare aus PR #69 (Issue #68).

## Änderungen

### Sicherheit: Bearer-Token-Hashing im mcp-Rate-Limiter

**Problem:** Der Bearer-Token wurde direkt als Cache-Key in `RateLimiter::for('mcp')` verwendet → Token landet als Klartext in Redis-Keys und potenziell in Logs/Monitoring.

**Fix:** Token wird vor Nutzung mit `hash('sha256', $token)` gehasht. Fallback auf IP-Adresse bleibt erhalten.

```php
$token = $request->bearerToken();
$identifier = $token !== null && $token !== ''
    ? hash('sha256', $token)
    : $request->ip();
return Limit::perMinute($limit)->by($identifier);
```

### Cleanup: webhooks-Limiter entfernt

**Problem:** `RateLimiter::for('webhooks', ...)` war nirgends per `throttle:webhooks` referenziert — toter Code mit Magic Number.

**Fix:** Limiter und zugehöriger `config/services.php`-Block entfernt. Kann ergänzt werden, sobald ein konkreter Webhook-Endpunkt entsteht.

## Tests

327/327 ✅

## Summary by Sourcery

Hash bearer tokens before using them as identifiers in the MCP rate limiter and remove the unused webhooks rate limiter configuration.

Bug Fixes:
- Prevent storing MCP bearer tokens in plaintext by hashing them before use in rate limiting.

Enhancements:
- Simplify rate limiting configuration by removing the unused webhooks limiter and its service configuration.