### PR TITLE
fix: Bearer-Token trimmen und resolveIdentifier()-Methode extrahieren

### DIFF
--- a/app/Providers/RateLimitingServiceProvider.php
+++ b/app/Providers/RateLimitingServiceProvider.php
@@ -13,12 +13,15 @@ class RateLimitingServiceProvider extends ServiceProvider
     {
         RateLimiter::for('mcp', function (Request $request) {
             $limit = config('services.mcp.rate_limit', 60);
-            $token = $request->bearerToken();
-            $identifier = $token !== null && $token !== ''
-                ? hash('sha256', $token)
-                : $request->ip();
 
-            return Limit::perMinute($limit)->by($identifier);
+            return Limit::perMinute($limit)->by($this->resolveIdentifier($request));
         });
+    }
+
+    private function resolveIdentifier(Request $request): string
+    {
+        $token = trim((string) $request->bearerToken());
+
+        return $token !== '' ? hash('sha256', $token) : $request->ip();
     }
 }


### PR DESCRIPTION
## Kontext

Follow-up auf PR #70 — adressiert zwei weitere Copilot-Review-Kommentare zu `RateLimitingServiceProvider`.

## Änderungen

### Token trimmen vor dem Hashen

`trim()` verhindert separate Rate-Limit-Buckets bei versehentlichem Whitespace im Bearer-Token (z.B. `" token"` und `"token"` erzeugen jetzt denselben sha256-Hash). `(string)`-Cast notwendig, da `bearerToken()` nullable ist.

### Identifier-Logik in private Methode extrahieren

```php
private function resolveIdentifier(Request $request): string
{
    $token = trim((string) $request->bearerToken());

    return $token !== '' ? hash('sha256', $token) : $request->ip();
}
```

`boot()` delegiert an `$this->resolveIdentifier($request)` — klarer, schlanker, erweiterbar (z.B. für User-basierte Keys in Zukunft).

## Tests

327/327 ✅

## Summary by Sourcery

Normalize rate limiting identifiers for MCP requests by delegating their resolution to a dedicated helper method.

Bug Fixes:
- Prevent separate rate-limit buckets caused by leading or trailing whitespace in Bearer tokens by trimming the token before hashing.

Enhancements:
- Extract identifier resolution into a private method to simplify the rate limiter configuration and prepare for future extensibility.