### PR TITLE
fix: null-Fallback für Request::ip() in resolveIdentifier()

### DIFF
--- a/app/Providers/RateLimitingServiceProvider.php
+++ b/app/Providers/RateLimitingServiceProvider.php
@@ -22,6 +22,6 @@ class RateLimitingServiceProvider extends ServiceProvider
     {
         $token = trim((string) $request->bearerToken());
 
-        return $token !== '' ? hash('sha256', $token) : $request->ip();
+        return $token !== '' ? hash('sha256', $token) : ($request->ip() ?? 'unknown');
     }
 }


### PR DESCRIPTION
## Kontext

Adressiert Copilot-Review-Kommentar auf PR #71 (Issue #68).

## Problem

`Request::ip()` kann `null` zurückgeben (z.B. CLI-Kontext, fehlkonfigurierter Proxy ohne `REMOTE_ADDR`). Der bisherige Rückgabetyp `: string` war daher nicht garantiert eingehalten.

## Fix

```php
return $token !== '' ? hash('sha256', $token) : ($request->ip() ?? 'unknown');
```

Expliziter Fallback auf `'unknown'` hält den deklarierten Rückgabetyp `string` ein und vermeidet einen potenziellen `TypeError` beim Aufruf von `Limit->by()`.

## Tests

327/327 ✅

## Summary by Sourcery

Bug Fixes:
- Add a fallback value when the request IP is null to prevent type errors in rate limiting identifier resolution.