### PR TITLE
feat: Enhance prismaZahlen retrieval with error reporting in phase-p5 view

### DIFF
--- a/app/Services/LangdockAgentService.php
+++ b/app/Services/LangdockAgentService.php
@@ -165,10 +165,8 @@ class LangdockAgentService
                     // Sprechende Fehlermeldung für 404 (Agent nicht gefunden)
                     if ($response->status() === 404) {
                         $agentId = $body['agentId'] ?? 'unknown';
-                        throw new LangdockAgentException(
-                            "Agent '{$agentId}' nicht gefunden - bitte Agent-ID prüfen oder Agent in Langdock reaktivieren.",
-                            404,
-                        );
+                        $message = __('langdock.errors.404_agent_not_found', ['agentId' => $agentId]);
+                        throw new LangdockAgentException($message, 404);
                     }
 
                     throw new LangdockAgentException(

--- a/lang/de/langdock.php
+++ b/lang/de/langdock.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'errors' => [
+        '404_agent_not_found' => "Agent '{agentId}' nicht gefunden — bitte Agent-ID prüfen oder Agent in Langdock reaktivieren.",
+    ],
+];

--- a/resources/views/livewire/recherche/agent-action-button.blade.php
+++ b/resources/views/livewire/recherche/agent-action-button.blade.php
@@ -63,14 +63,18 @@ new class extends Component {
         }
 
         // --- Ergebnisse abgeschlossener Vorphasen ---
-        $previousResults = rescue(fn () => PhaseAgentResult::where('projekt_id', $this->projekt->id)
-            ->where('phase_nr', '<', $this->phaseNr)
-            ->where('status', 'completed')
-            ->whereNotNull('content')
-            ->orderBy('phase_nr')
-            ->orderByDesc('created_at')
-            ->get()
-            ->unique('phase_nr'), collect());
+        $previousResults = rescue(
+            fn () => PhaseAgentResult::where('projekt_id', $this->projekt->id)
+                ->where('phase_nr', '<', $this->phaseNr)
+                ->where('status', 'completed')
+                ->whereNotNull('content')
+                ->orderBy('phase_nr')
+                ->orderByDesc('created_at')
+                ->get()
+                ->unique('phase_nr'),
+            collect(),
+            report: true,
+        );
 
         if ($previousResults->isNotEmpty()) {
             $lines[] = '';
@@ -82,12 +86,20 @@ new class extends Component {
         }
 
         // --- Verfügbare Dokumente ---
-        $paperCount = rescue(fn () => (int) DB::selectOne(
-            'SELECT COUNT(*) AS cnt FROM paper_embeddings WHERE projekt_id = ?::uuid',
-            [$this->projekt->id]
-        )?->cnt, 0);
+        $paperCount = rescue(
+            fn () => (int) DB::selectOne(
+                'SELECT COUNT(*) AS cnt FROM paper_embeddings WHERE projekt_id = ?::uuid',
+                [$this->projekt->id]
+            )?->cnt,
+            0,
+            report: true,
+        );
 
-        $trefferCount = rescue(fn () => $this->projekt->p5Treffer()->count(), 0);
+        $trefferCount = rescue(
+            fn () => $this->projekt->p5Treffer()->count(),
+            0,
+            report: true,
+        );
 
         if ($paperCount > 0 || $trefferCount > 0) {
             $lines[] = '';

--- a/resources/views/livewire/recherche/phase-p1.blade.php
+++ b/resources/views/livewire/recherche/phase-p1.blade.php
@@ -290,11 +290,31 @@ new class extends Component {
     {
         $pid = $this->projekt->id;
         return [
-            'strukturmodelle' => rescue(fn () => P1Strukturmodellwahl::where('projekt_id', $pid)->get(), collect()),
-            'komponenten' => rescue(fn () => P1Komponente::where('projekt_id', $pid)->get(), collect()),
-            'kriterien' => rescue(fn () => P1Kriterium::where('projekt_id', $pid)->get(), collect()),
-            'warnsignale' => rescue(fn () => P1Warnsignal::where('projekt_id', $pid)->orderBy('lfd_nr')->get(), collect()),
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 1)->whereNotNull('content')->latest()->first()),
+            'strukturmodelle' => rescue(
+                fn () => P1Strukturmodellwahl::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'komponenten' => rescue(
+                fn () => P1Komponente::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'kriterien' => rescue(
+                fn () => P1Kriterium::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'warnsignale' => rescue(
+                fn () => P1Warnsignal::where('projekt_id', $pid)->orderBy('lfd_nr')->get(),
+                collect(),
+                report: true,
+            ),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 1)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p2.blade.php
+++ b/resources/views/livewire/recherche/phase-p2.blade.php
@@ -233,21 +233,45 @@ new class extends Component {
 
     public function hasRunningAgentJob(): bool
     {
-        return rescue(fn () => PhaseAgentResult::where('projekt_id', $this->projekt->id)
-            ->where('phase_nr', 2)
-            ->where('status', 'pending')
-            ->exists(), false);
+        return rescue(
+            fn () => PhaseAgentResult::where('projekt_id', $this->projekt->id)
+                ->where('phase_nr', 2)
+                ->where('status', 'pending')
+                ->exists(),
+            false,
+            report: true,
+        );
     }
 
     public function with(): array
     {
         $pid = $this->projekt->id;
         return [
-            'reviewTypen' => rescue(fn () => P2ReviewTypEntscheidung::where('projekt_id', $pid)->get(), collect()),
-            'cluster' => rescue(fn () => P2Cluster::where('projekt_id', $pid)->get(), collect()),
-            'mappings' => rescue(fn () => P2MappingSuchstringKomponente::where('projekt_id', $pid)->get(), collect()),
-            'trefferlisten' => rescue(fn () => P2Trefferliste::where('projekt_id', $pid)->orderBy('suchdatum', 'desc')->get(), collect()),
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 2)->whereNotNull('content')->latest()->first()),
+            'reviewTypen' => rescue(
+                fn () => P2ReviewTypEntscheidung::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'cluster' => rescue(
+                fn () => P2Cluster::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'mappings' => rescue(
+                fn () => P2MappingSuchstringKomponente::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'trefferlisten' => rescue(
+                fn () => P2Trefferliste::where('projekt_id', $pid)->orderBy('suchdatum', 'desc')->get(),
+                collect(),
+                report: true,
+            ),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 2)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p3.blade.php
+++ b/resources/views/livewire/recherche/phase-p3.blade.php
@@ -244,11 +244,31 @@ new class extends Component {
     {
         $pid = $this->projekt->id;
         return [
-            'datenbanken' => rescue(fn () => P3Datenbankmatrix::where('projekt_id', $pid)->get(), collect()),
-            'disziplinen' => rescue(fn () => P3Disziplin::where('projekt_id', $pid)->get(), collect()),
-            'geoFilter' => rescue(fn () => P3GeografischerFilter::where('projekt_id', $pid)->get(), collect()),
-            'graueLiteratur' => rescue(fn () => P3GraueLiteratur::where('projekt_id', $pid)->get(), collect()),
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 3)->whereNotNull('content')->latest()->first()),
+            'datenbanken' => rescue(
+                fn () => P3Datenbankmatrix::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'disziplinen' => rescue(
+                fn () => P3Disziplin::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'geoFilter' => rescue(
+                fn () => P3GeografischerFilter::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'graueLiteratur' => rescue(
+                fn () => P3GraueLiteratur::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 3)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p4.blade.php
+++ b/resources/views/livewire/recherche/phase-p4.blade.php
@@ -157,9 +157,21 @@ new class extends Component {
     {
         $pid = $this->projekt->id;
         return [
-            'suchstrings' => rescue(fn () => P4Suchstring::where('projekt_id', $pid)->with('anpassungsprotokoll')->get(), collect()),
-            'thesaurusMappings' => rescue(fn () => P4ThesaurusMapping::where('projekt_id', $pid)->get(), collect()),
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 4)->whereNotNull('content')->latest()->first()),
+            'suchstrings' => rescue(
+                fn () => P4Suchstring::where('projekt_id', $pid)->with('anpassungsprotokoll')->get(),
+                collect(),
+                report: true,
+            ),
+            'thesaurusMappings' => rescue(
+                fn () => P4ThesaurusMapping::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 4)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p5.blade.php
+++ b/resources/views/livewire/recherche/phase-p5.blade.php
@@ -239,7 +239,11 @@ new class extends Component {
     public function with(): array
     {
         $pid = $this->projekt->id;
-        $trefferQuery = rescue(fn () => P5Treffer::where('projekt_id', $pid)->with('screeningEntscheidungen'), null);
+        $trefferQuery = rescue(
+            fn () => P5Treffer::where('projekt_id', $pid)->with('screeningEntscheidungen'),
+            null,
+            report: true,
+        );
         if ($trefferQuery) {
             if ($this->trefferFilter === 'duplikate') {
                 $trefferQuery->where('ist_duplikat', true);
@@ -248,13 +252,43 @@ new class extends Component {
             }
         }
         return [
-            'prismaZahlen' => rescue(fn () => P5PrismaZahlen::where('projekt_id', $pid)->first()),
-            'screeningKriterien' => rescue(fn () => P5ScreeningKriterium::where('projekt_id', $pid)->get(), collect()),
-            'treffer' => $trefferQuery ? rescue(fn () => $trefferQuery->orderBy('record_id')->get(), collect()) : collect(),
-            'trefferGesamt' => rescue(fn () => P5Treffer::where('projekt_id', $pid)->count(), 0),
-            'trefferDuplikate' => rescue(fn () => P5Treffer::where('projekt_id', $pid)->where('ist_duplikat', true)->count(), 0),
-            'tools' => rescue(fn () => P5ToolEntscheidung::where('projekt_id', $pid)->get(), collect()),
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 5)->whereNotNull('content')->latest()->first()),
+            'prismaZahlen' => rescue(
+                fn () => P5PrismaZahlen::where('projekt_id', $pid)->first(),
+                null,
+                report: true,
+            ),
+            'screeningKriterien' => rescue(
+                fn () => P5ScreeningKriterium::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'treffer' => $trefferQuery
+                ? rescue(
+                    fn () => $trefferQuery->orderBy('record_id')->get(),
+                    collect(),
+                    report: true,
+                )
+                : collect(),
+            'trefferGesamt' => rescue(
+                fn () => P5Treffer::where('projekt_id', $pid)->count(),
+                0,
+                report: true,
+            ),
+            'trefferDuplikate' => rescue(
+                fn () => P5Treffer::where('projekt_id', $pid)->where('ist_duplikat', true)->count(),
+                0,
+                report: true,
+            ),
+            'tools' => rescue(
+                fn () => P5ToolEntscheidung::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 5)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p6.blade.php
+++ b/resources/views/livewire/recherche/phase-p6.blade.php
@@ -144,16 +144,32 @@ new class extends Component {
     public function with(): array
     {
         $pid = $this->projekt->id;
-        $treffer = rescue(fn () => P5Treffer::where('projekt_id', $pid)->where('ist_duplikat', false)->get(), collect());
+        $treffer = rescue(
+            fn () => P5Treffer::where('projekt_id', $pid)->where('ist_duplikat', false)->get(),
+            collect(),
+            report: true,
+        );
         $bewertungen = $treffer->isNotEmpty()
-            ? rescue(fn () => P6Qualitaetsbewertung::whereIn('treffer_id', $treffer->pluck('id'))->with('treffer')->get(), collect())
+            ? rescue(
+                fn () => P6Qualitaetsbewertung::whereIn('treffer_id', $treffer->pluck('id'))->with('treffer')->get(),
+                collect(),
+                report: true,
+            )
             : collect();
         return [
             'treffer' => $treffer,
             'bewertungen' => $bewertungen,
-            'lucken' => rescue(fn () => P6Luckenanalyse::where('projekt_id', $pid)->get(), collect()),
+            'lucken' => rescue(
+                fn () => P6Luckenanalyse::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
             'robVerteilung' => $bewertungen->groupBy('gesamturteil')->map->count(),
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 6)->whereNotNull('content')->latest()->first()),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 6)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p7.blade.php
+++ b/resources/views/livewire/recherche/phase-p7.blade.php
@@ -262,16 +262,40 @@ new class extends Component {
     public function with(): array
     {
         $pid = $this->projekt->id;
-        $treffer = rescue(fn () => P5Treffer::where('projekt_id', $pid)->where('ist_duplikat', false)->get(), collect());
+        $treffer = rescue(
+            fn () => P5Treffer::where('projekt_id', $pid)->where('ist_duplikat', false)->get(),
+            collect(),
+            report: true,
+        );
         return [
-            'syntheseMethoden' => rescue(fn () => P7SyntheseMethode::where('projekt_id', $pid)->get(), collect()),
+            'syntheseMethoden' => rescue(
+                fn () => P7SyntheseMethode::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
             'datenextraktionen' => $treffer->isNotEmpty()
-                ? rescue(fn () => P7Datenextraktion::whereIn('treffer_id', $treffer->pluck('id'))->with('treffer')->get(), collect())
+                ? rescue(
+                    fn () => P7Datenextraktion::whereIn('treffer_id', $treffer->pluck('id'))->with('treffer')->get(),
+                    collect(),
+                    report: true,
+                )
                 : collect(),
-            'muster' => rescue(fn () => P7MusterKonsistenz::where('projekt_id', $pid)->get(), collect()),
-            'gradeEinschaetzungen' => rescue(fn () => P7GradeEinschaetzung::where('projekt_id', $pid)->get(), collect()),
+            'muster' => rescue(
+                fn () => P7MusterKonsistenz::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'gradeEinschaetzungen' => rescue(
+                fn () => P7GradeEinschaetzung::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
             'treffer' => $treffer,
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 7)->whereNotNull('content')->latest()->first()),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 7)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/resources/views/livewire/recherche/phase-p8.blade.php
+++ b/resources/views/livewire/recherche/phase-p8.blade.php
@@ -243,15 +243,38 @@ new class extends Component {
     public function with(): array
     {
         $pid = $this->projekt->id;
-        $suchstrings = rescue(fn () => P4Suchstring::where('projekt_id', $pid)->get(), collect());
-        $suchstringIds = $suchstrings->pluck('id');
+        $suchstrings = rescue(
+            fn () => P4Suchstring::where('projekt_id', $pid)->get(),
+            collect(),
+            report: true,
+        );
         return [
-            'suchprotokolle' => rescue(fn () => P8Suchprotokoll::where('projekt_id', $pid)->with('suchstring')->get(), collect()),
-            'limitationen' => rescue(fn () => P8Limitation::where('projekt_id', $pid)->get(), collect()),
-            'reproduzierbarkeit' => rescue(fn () => P8Reproduzierbarkeitspruefung::where('projekt_id', $pid)->get(), collect()),
-            'updatePlaene' => rescue(fn () => P8UpdatePlan::where('projekt_id', $pid)->get(), collect()),
+            'suchprotokolle' => rescue(
+                fn () => P8Suchprotokoll::where('projekt_id', $pid)->with('suchstring')->get(),
+                collect(),
+                report: true,
+            ),
+            'limitationen' => rescue(
+                fn () => P8Limitation::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'reproduzierbarkeit' => rescue(
+                fn () => P8Reproduzierbarkeitspruefung::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
+            'updatePlaene' => rescue(
+                fn () => P8UpdatePlan::where('projekt_id', $pid)->get(),
+                collect(),
+                report: true,
+            ),
             'suchstrings' => $suchstrings,
-            'latestAgentResult' => rescue(fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 8)->whereNotNull('content')->latest()->first()),
+            'latestAgentResult' => rescue(
+                fn () => PhaseAgentResult::where('projekt_id', $pid)->where('phase_nr', 8)->whereNotNull('content')->latest()->first(),
+                null,
+                report: true,
+            ),
         ];
     }
 }; ?>

--- a/tests/Feature/Services/AgentActionButtonErrorHandlingTest.php
+++ b/tests/Feature/Services/AgentActionButtonErrorHandlingTest.php
@@ -21,34 +21,6 @@ function makeTestProject(): Projekt
     ]);
 }
 
-// ─── buildContextMessages() Error Handling ──────────────────
-
-test('buildContextMessages handles paper_embeddings query failure gracefully', function () {
-    Queue::fake();
-    config(['services.langdock.scoping_mapping_agent' => 'test-agent-id']);
-
-    $projekt = makeTestProject();
-
-    // Mock paper_embeddings query to fail without crashing
-    Livewire\Volt\Component::class;
-    // In practice: the rescue() in buildContextMessages() prevents this from throwing
-    // This test verifies that rescue() defaults to 0 when query fails
-
-    expect(true)->toBeTrue(); // Placeholder: actual integration test runs via browser/livewire component
-});
-
-test('buildContextMessages handles p5Treffer() failure gracefully', function () {
-    Queue::fake();
-    config(['services.langdock.scoping_mapping_agent' => 'test-agent-id']);
-
-    $projekt = makeTestProject();
-
-    // The rescue() in buildContextMessages() for $trefferCount defaults to 0
-    // preventing the component from crashing
-
-    expect(true)->toBeTrue(); // Placeholder: actual integration test runs via livewire
-});
-
 // ─── LangdockAgentService 404 Handling ──────────────────────
 
 test('LangdockAgentService handles 404 with descriptive error message', function () {
@@ -66,11 +38,13 @@ test('LangdockAgentService handles 404 with descriptive error message', function
 
     $service = app(LangdockAgentService::class);
 
-    expect(fn () => $service->call('unknown-agent-id', [['role' => 'user', 'content' => 'test']]))
-        ->toThrow(
-            \App\Services\LangdockAgentException::class,
-            'Agent \'unknown-agent-id\' nicht gefunden',
-        );
+    try {
+        $service->call('unknown-agent-id', [['role' => 'user', 'content' => 'test']]);
+        $this->fail('Expected LangdockAgentException was not thrown.');
+    } catch (\App\Services\LangdockAgentException $exception) {
+        expect($exception->getMessage())->toContain('unknown-agent-id');
+        expect($exception->getMessage())->toContain('nicht gefunden');
+    }
 });
 
 test('LangdockAgentService handles 500 with generic error message', function () {
@@ -92,6 +66,3 @@ test('LangdockAgentService handles 500 with generic error message', function () 
     expect(fn () => $service->call('test-agent', [['role' => 'user', 'content' => 'test']]))
         ->toThrow(\App\Services\LangdockAgentException::class);
 });
-
-// ─── Phase Query Resilience ────────────────────────────────
-


### PR DESCRIPTION
## Beschreibung

<!-- Was ändert dieser PR? Verlinke das zugehörige Issue mit "Closes #…" -->

Closes #

## Änderungstyp

- [ ] Bug-Fix
- [ ] Feature
- [ ] Refactoring
- [ ] Dokumentation
- [ ] CI / Infrastruktur

## Checkliste

- [ ] Code folgt den bestehenden Konventionen (Pint-Lint bestanden)
- [ ] Tests geschrieben / aktualisiert und grün
- [ ] Keine neuen Compiler-/Linter-Warnungen
- [ ] Datenbank-Migration enthalten? → Rollback getestet
- [ ] Breaking Change? → In Beschreibung dokumentiert
- [ ] Deploy-Hinweis nötig? → Unten ergänzt

## Deploy-Hinweise

<!-- Besondere Schritte nach dem Merge (z. B. Env-Variablen, einmaliger Artisan-Befehl)? -->

Keine.

## Summary by Sourcery

Improve robustness and observability of Livewire research phases and Langdock agent integration by reporting database/query failures and localizing error messages.

Bug Fixes:
- Ensure LangdockAgentService 404 errors expose the relevant agent ID and a clear not-found message while still throwing a domain exception.

Enhancements:
- Enable error reporting for all rescue-wrapped database and query operations across research phases P1–P8 and the agent action button context builder while keeping existing fallbacks.
- Standardize handling of missing latest PhaseAgentResult values by providing explicit null defaults instead of implicit behavior.
- Remove placeholder tests that did not assert behavior and adjust LangdockAgentService 404 tests to assert on localized, descriptive exception messages.

Documentation:
- Add a German localization entry for Langdock agent-not-found errors to centralize and standardize the user-facing message.