### PR TITLE
feat: Simplified Agent Pipeline — Markdown Output (Issue #136)

### DIFF
--- a/app/Http/Controllers/AgentResultWebhookController.php
+++ b/app/Http/Controllers/AgentResultWebhookController.php
@@ -37,6 +37,9 @@ class AgentResultWebhookController extends Controller
         // Persist markdown files to storage
         $basePath = "recherche/{$projektId}/{$phase}";
         foreach ($mdFiles as $file) {
+            if (!$this->validateFilePath($file['path'])) {
+                return response()->json(['error' => 'Invalid file path: ' . $file['path']], 400);
+            }
             Storage::disk('local')->put("{$basePath}/{$file['path']}", $file['content']);
         }
 
@@ -65,6 +68,32 @@ class AgentResultWebhookController extends Controller
         );
 
         return response()->json(['status' => 'success', 'phase' => $phase], 200);
+    }
+
+    private function validateFilePath(string $path): bool
+    {
+        // Reject parent directory traversal
+        if (str_contains($path, '..')) {
+            return false;
+        }
+        // Reject absolute paths
+        if (str_starts_with($path, '/') || str_starts_with($path, '\\')) {
+            return false;
+        }
+        // Reject double slashes and backslashes
+        if (str_contains($path, '//') || str_contains($path, '\\')) {
+            return false;
+        }
+        // Require .md extension
+        if (!str_ends_with($path, '.md')) {
+            return false;
+        }
+        // Only allow safe filename characters
+        if (!preg_match('/^[\w\-]+\.md$/', $path)) {
+            return false;
+        }
+
+        return true;
     }
 
     private function verifySignature(Request $request): bool

--- a/resources/views/livewire/recherche/ergebnisse-anzeigen.blade.php
+++ b/resources/views/livewire/recherche/ergebnisse-anzeigen.blade.php
@@ -18,6 +18,12 @@ new class extends Component {
         // Authorize using ProjektPolicy
         $this->authorize('view', $this->projekt);
 
+        // Strict whitelist to prevent path traversal
+        $allowedPhases = ['recherche', 'screening', 'auswertung'];
+        if (!in_array($this->phase, $allowedPhases, strict: true)) {
+            abort(404);
+        }
+
         $basePath = "recherche/{$this->projekt->id}/{$this->phase}";
 
         // List files in the directory
@@ -36,7 +42,10 @@ new class extends Component {
             $combinedContent .= $content . "\n\n---\n\n";
         }
 
-        $this->renderedContent = Str::markdown($combinedContent);
+        $this->renderedContent = Str::markdown($combinedContent, [
+            'html_input' => 'strip',
+            'allow_unsafe_links' => false,
+        ]);
     }
 }; ?>
 

--- a/tests/Feature/Http/Controllers/AgentResultWebhookControllerTest.php
+++ b/tests/Feature/Http/Controllers/AgentResultWebhookControllerTest.php
@@ -1,102 +1,122 @@
 <?php
 
-namespace Tests\Feature\Http\Controllers;
-
 use App\Models\Recherche\Projekt;
 use App\Models\PhaseAgentResult;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
 
-class AgentResultWebhookControllerTest extends TestCase
-{
-    use RefreshDatabase;
+beforeEach(function () {
+    Storage::fake('local');
+    $this->owner = User::factory()->withoutTwoFactor()->create();
+    $this->projekt = Projekt::factory()->create(['user_id' => $this->owner->id]);
+});
 
-    private string $testProjectId;
-    private User $owner;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->owner = User::factory()->withoutTwoFactor()->create();
-        $projekt = Projekt::factory()->create(['user_id' => $this->owner->id]);
-        $this->testProjectId = $projekt->id;
-
-        Storage::fake('local');
-    }
-
-    public function test_webhook_handler_persists_markdown_files(): void
-    {
-        $payload = [
-            'meta' => [
-                'projekt_id' => $this->testProjectId,
-                'workspace_id' => 'workspace-123',
-                'phase' => 'screening',
-            ],
-            'result' => [
-                'type' => 'final_report',
-                'summary' => '# Screening Results',
-                'data' => [
-                    'md_files' => [
-                        [
-                            'path' => 'screening-bericht.md',
-                            'content' => '# Screening-Ergebnis\n\nTopics: 42 papers screened.',
-                        ],
-                        [
-                            'path' => 'einschluss-liste.md',
-                            'content' => '# Included Papers\n\n- Paper 1\n- Paper 2',
-                        ],
-                    ],
+test('webhook handler persists markdown files', function () {
+    $payload = [
+        'meta' => [
+            'projekt_id' => $this->projekt->id,
+            'workspace_id' => 'workspace-123',
+            'phase' => 'screening',
+        ],
+        'result' => [
+            'type' => 'final_report',
+            'summary' => '# Screening Results',
+            'data' => [
+                'md_files' => [
+                    ['path' => 'screening-bericht.md', 'content' => '# Screening-Ergebnis\n\nTopics: 42 papers screened.'],
+                    ['path' => 'einschluss-liste.md', 'content' => '# Included Papers\n\n- Paper 1\n- Paper 2'],
                 ],
             ],
-        ];
+        ],
+    ];
 
-        $response = $this->postJson('/api/webhooks/langdock/agent-result', $payload, [
-            'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($payload), config('services.langdock.webhook_secret')),
-            'X-Langdock-Timestamp' => now()->unix(),
-        ]);
+    $response = $this->postJson('/api/webhooks/langdock/agent-result', $payload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($payload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ]);
 
-        $response->assertStatus(200);
+    $response->assertStatus(200);
 
-        // Verify files written to storage
-        Storage::disk('local')->assertExists("recherche/{$this->testProjectId}/screening/screening-bericht.md");
-        Storage::disk('local')->assertExists("recherche/{$this->testProjectId}/screening/einschluss-liste.md");
+    Storage::disk('local')->assertExists("recherche/{$this->projekt->id}/screening/screening-bericht.md");
+    Storage::disk('local')->assertExists("recherche/{$this->projekt->id}/screening/einschluss-liste.md");
 
-        // Verify PhaseAgentResult record created
-        $this->assertDatabaseHas('phase_agent_results', [
-            'projekt_id' => $this->testProjectId,
+    $this->assertDatabaseHas('phase_agent_results', [
+        'projekt_id' => $this->projekt->id,
+        'phase' => 'screening',
+        'status' => 'completed',
+    ]);
+});
+
+test('webhook handler rejects invalid signature', function () {
+    $payload = [
+        'meta' => ['projekt_id' => $this->projekt->id, 'phase' => 'screening'],
+        'result' => ['type' => 'final_report', 'data' => ['md_files' => []]],
+    ];
+
+    $response = $this->postJson('/api/webhooks/langdock/agent-result', $payload, [
+        'X-Langdock-Signature' => 'sha256=invalid',
+        'X-Langdock-Timestamp' => now()->unix(),
+    ]);
+
+    $response->assertStatus(401);
+});
+
+test('webhook handler validates required fields', function () {
+    $invalidPayload = ['meta' => [], 'result' => []];
+
+    $response = $this->postJson('/api/webhooks/langdock/agent-result', $invalidPayload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($invalidPayload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['meta.projekt_id', 'meta.phase', 'result.data.md_files']);
+});
+
+test('webhook handler rejects path traversal attempts', function () {
+    $payload = [
+        'meta' => [
+            'projekt_id' => $this->projekt->id,
             'phase' => 'screening',
-            'status' => 'completed',
-        ]);
-    }
+        ],
+        'result' => [
+            'type' => 'final_report',
+            'data' => [
+                'md_files' => [
+                    ['path' => '../../../dangerous.md', 'content' => 'malicious content'],
+                ],
+            ],
+        ],
+    ];
 
-    public function test_webhook_handler_rejects_invalid_signature(): void
-    {
-        $payload = [
-            'meta' => ['projekt_id' => $this->testProjectId, 'phase' => 'screening'],
-            'result' => ['type' => 'final_report', 'data' => ['md_files' => []]],
-        ];
+    $response = $this->postJson('/api/webhooks/langdock/agent-result', $payload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($payload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ]);
 
-        $response = $this->postJson('/api/webhooks/langdock/agent-result', $payload, [
-            'X-Langdock-Signature' => 'sha256=invalid',
-            'X-Langdock-Timestamp' => now()->unix(),
-        ]);
+    $response->assertStatus(400);
+});
 
-        $response->assertStatus(401);
-    }
+test('webhook handler rejects absolute paths', function () {
+    $payload = [
+        'meta' => [
+            'projekt_id' => $this->projekt->id,
+            'phase' => 'screening',
+        ],
+        'result' => [
+            'type' => 'final_report',
+            'data' => [
+                'md_files' => [
+                    ['path' => '/etc/passwd.md', 'content' => 'malicious content'],
+                ],
+            ],
+        ],
+    ];
 
-    public function test_webhook_handler_validates_required_fields(): void
-    {
-        $invalidPayload = ['meta' => [], 'result' => []];
+    $response = $this->postJson('/api/webhooks/langdock/agent-result', $payload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($payload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ]);
 
-        $response = $this->postJson('/api/webhooks/langdock/agent-result', $invalidPayload, [
-            'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($invalidPayload), config('services.langdock.webhook_secret')),
-            'X-Langdock-Timestamp' => now()->unix(),
-        ]);
-
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['meta.projekt_id', 'meta.phase', 'result.data.md_files']);
-    }
-}
+    $response->assertStatus(400);
+});

--- a/tests/Feature/Integration/AgentPipelineE2ETest.php
+++ b/tests/Feature/Integration/AgentPipelineE2ETest.php
@@ -1,94 +1,75 @@
 <?php
 
-namespace Tests\Feature\Integration;
-
 use App\Models\Recherche\Projekt;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
 
-class AgentPipelineE2ETest extends TestCase
-{
-    use RefreshDatabase;
+beforeEach(function () {
+    Storage::fake('local');
+    $this->owner = User::factory()->withoutTwoFactor()->create();
+    $this->projekt = Projekt::factory()->create(['user_id' => $this->owner->id]);
+});
 
-    private User $owner;
-    private Projekt $projekt;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->owner = User::factory()->withoutTwoFactor()->create();
-        $this->projekt = Projekt::factory()->create(['user_id' => $this->owner->id]);
-
-        Storage::fake('local');
-    }
-
-    public function test_webhook_to_viewer_end_to_end(): void
-    {
-        $webhookPayload = [
-            'meta' => [
-                'projekt_id' => $this->projekt->id,
-                'workspace_id' => 'workspace-123',
-                'phase' => 'screening',
-            ],
-            'result' => [
-                'type' => 'final_report',
-                'summary' => '# Screening Results',
-                'data' => [
-                    'md_files' => [
-                        ['path' => 'screening-bericht.md', 'content' => '# Screening-Ergebnis\n\n42 papers screened.'],
-                        ['path' => 'einschluss-liste.md', 'content' => '# Included Papers\n\n- Paper 1\n- Paper 2'],
-                    ],
+test('webhook to viewer end to end', function () {
+    $webhookPayload = [
+        'meta' => [
+            'projekt_id' => $this->projekt->id,
+            'workspace_id' => 'workspace-123',
+            'phase' => 'screening',
+        ],
+        'result' => [
+            'type' => 'final_report',
+            'summary' => '# Screening Results',
+            'data' => [
+                'md_files' => [
+                    ['path' => 'screening-bericht.md', 'content' => '# Screening-Ergebnis\n\n42 papers screened.'],
+                    ['path' => 'einschluss-liste.md', 'content' => '# Included Papers\n\n- Paper 1\n- Paper 2'],
                 ],
             ],
-        ];
+        ],
+    ];
 
-        $webhookResponse = $this->postJson('/api/webhooks/langdock/agent-result', $webhookPayload, [
-            'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($webhookPayload), config('services.langdock.webhook_secret')),
-            'X-Langdock-Timestamp' => now()->unix(),
-        ]);
+    $webhookResponse = $this->postJson('/api/webhooks/langdock/agent-result', $webhookPayload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($webhookPayload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ]);
 
-        $webhookResponse->assertStatus(200);
-        Storage::disk('local')->assertExists("recherche/{$this->projekt->id}/screening/screening-bericht.md");
-        Storage::disk('local')->assertExists("recherche/{$this->projekt->id}/screening/einschluss-liste.md");
+    $webhookResponse->assertStatus(200);
+    Storage::disk('local')->assertExists("recherche/{$this->projekt->id}/screening/screening-bericht.md");
+    Storage::disk('local')->assertExists("recherche/{$this->projekt->id}/screening/einschluss-liste.md");
 
-        $viewerResponse = $this->actingAs($this->owner)
-            ->get("/recherche/{$this->projekt->id}/ergebnisse/screening");
+    $viewerResponse = $this->actingAs($this->owner)
+        ->get("/recherche/{$this->projekt->id}/ergebnisse/screening");
 
-        $viewerResponse->assertStatus(200);
-    }
+    $viewerResponse->assertStatus(200);
+});
 
-    public function test_webhook_then_viewer_unauthorized(): void
-    {
-        $other = User::factory()->withoutTwoFactor()->create();
+test('webhook then viewer unauthorized', function () {
+    $other = User::factory()->withoutTwoFactor()->create();
 
-        $webhookPayload = [
-            'meta' => ['projekt_id' => $this->projekt->id, 'workspace_id' => 'ws-123', 'phase' => 'screening'],
-            'result' => ['type' => 'final_report', 'summary' => '# Results', 'data' => ['md_files' => [['path' => 'report.md', 'content' => '# Report']]]],
-        ];
+    $webhookPayload = [
+        'meta' => ['projekt_id' => $this->projekt->id, 'workspace_id' => 'ws-123', 'phase' => 'screening'],
+        'result' => ['type' => 'final_report', 'summary' => '# Results', 'data' => ['md_files' => [['path' => 'report.md', 'content' => '# Report']]]],
+    ];
 
-        $this->postJson('/api/webhooks/langdock/agent-result', $webhookPayload, [
-            'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($webhookPayload), config('services.langdock.webhook_secret')),
-            'X-Langdock-Timestamp' => now()->unix(),
-        ])->assertStatus(200);
+    $this->postJson('/api/webhooks/langdock/agent-result', $webhookPayload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($webhookPayload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ])->assertStatus(200);
 
-        $this->actingAs($other)->get("/recherche/{$this->projekt->id}/ergebnisse/screening")->assertStatus(403);
-    }
+    $this->actingAs($other)->get("/recherche/{$this->projekt->id}/ergebnisse/screening")->assertStatus(403);
+});
 
-    public function test_webhook_then_viewer_invalid_phase(): void
-    {
-        $webhookPayload = [
-            'meta' => ['projekt_id' => $this->projekt->id, 'workspace_id' => 'ws-123', 'phase' => 'screening'],
-            'result' => ['type' => 'final_report', 'summary' => '# Results', 'data' => ['md_files' => [['path' => 'report.md', 'content' => '# Report']]]],
-        ];
+test('webhook then viewer invalid phase', function () {
+    $webhookPayload = [
+        'meta' => ['projekt_id' => $this->projekt->id, 'workspace_id' => 'ws-123', 'phase' => 'screening'],
+        'result' => ['type' => 'final_report', 'summary' => '# Results', 'data' => ['md_files' => [['path' => 'report.md', 'content' => '# Report']]]],
+    ];
 
-        $this->postJson('/api/webhooks/langdock/agent-result', $webhookPayload, [
-            'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($webhookPayload), config('services.langdock.webhook_secret')),
-            'X-Langdock-Timestamp' => now()->unix(),
-        ])->assertStatus(200);
+    $this->postJson('/api/webhooks/langdock/agent-result', $webhookPayload, [
+        'X-Langdock-Signature' => 'sha256=' . hash_hmac('sha256', json_encode($webhookPayload), config('services.langdock.webhook_secret')),
+        'X-Langdock-Timestamp' => now()->unix(),
+    ])->assertStatus(200);
 
-        $this->actingAs($this->owner)->get("/recherche/{$this->projekt->id}/ergebnisse/auswertung")->assertStatus(404);
-    }
-}
+    $this->actingAs($this->owner)->get("/recherche/{$this->projekt->id}/ergebnisse/ungueltig-phase")->assertStatus(404);
+});

--- a/tests/Feature/Volt/Recherche/ErgebnisseAnzeigenTest.php
+++ b/tests/Feature/Volt/Recherche/ErgebnisseAnzeigenTest.php
@@ -1,104 +1,78 @@
 <?php
 
-namespace Tests\Feature\Volt\Recherche;
-
 use App\Models\Recherche\Projekt;
 use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Storage;
-use Tests\TestCase;
 
-class ErgebnisseAnzeigenTest extends TestCase
-{
-    use RefreshDatabase;
+beforeEach(function () {
+    Storage::fake('local');
+    $this->owner = User::factory()->withoutTwoFactor()->create();
+    $this->projekt = Projekt::factory()->create(['user_id' => $this->owner->id]);
+});
 
-    public function test_md_viewer_displays_markdown_files(): void
-    {
-        $owner = User::factory()->withoutTwoFactor()->create();
-        $projekt = Projekt::factory()->create(['user_id' => $owner->id]);
+test('md viewer displays markdown files', function () {
+    Storage::disk('local')->put(
+        "recherche/{$this->projekt->id}/screening/results.md",
+        "# Screening Results\n\nThis is the screening report."
+    );
 
-        // Don't use fake storage - use real storage
-        $dir = storage_path("app/recherche/{$projekt->id}/screening");
-        @mkdir($dir, 0755, true);
-        file_put_contents("$dir/results.md", "# Screening Results\n\nThis is the screening report.");
+    $response = $this->actingAs($this->owner)
+        ->get("/recherche/{$this->projekt->id}/ergebnisse/screening");
 
-        try {
-            $response = $this->actingAs($owner)
-                ->get("/recherche/{$projekt->id}/ergebnisse/screening");
+    $response->assertStatus(200);
+    $response->assertSee('<h1>Screening Results</h1>', false);
+    $response->assertSee('This is the screening report.');
+});
 
-            $response->assertStatus(200);
-            $response->assertSee('<h1>Screening Results</h1>');
-            $response->assertSee('This is the screening report.');
-        } finally {
-            // Cleanup
-            @unlink("$dir/results.md");
-            @rmdir($dir);
-        }
-    }
+test('md viewer enforces projekt policy', function () {
+    $nonOwner = User::factory()->withoutTwoFactor()->create();
 
-    public function test_md_viewer_enforces_projekt_policy(): void
-    {
-        $owner = User::factory()->withoutTwoFactor()->create();
-        $nonOwner = User::factory()->withoutTwoFactor()->create();
-        $projekt = Projekt::factory()->create(['user_id' => $owner->id]);
+    Storage::disk('local')->put(
+        "recherche/{$this->projekt->id}/screening/results.md",
+        "# Screening Results"
+    );
 
-        // Don't use fake storage - use real storage
-        $dir = storage_path("app/recherche/{$projekt->id}/screening");
-        @mkdir($dir, 0755, true);
-        file_put_contents("$dir/results.md", "# Screening Results");
+    $response = $this->actingAs($nonOwner)
+        ->get("/recherche/{$this->projekt->id}/ergebnisse/screening");
 
-        try {
-            $response = $this->actingAs($nonOwner)
-                ->get("/recherche/{$projekt->id}/ergebnisse/screening");
+    $response->assertStatus(403);
+});
 
-            $response->assertStatus(403);
-        } finally {
-            // Cleanup
-            @unlink("$dir/results.md");
-            @rmdir($dir);
-        }
-    }
+test('md viewer returns 404 for missing files', function () {
+    $response = $this->actingAs($this->owner)
+        ->get("/recherche/{$this->projekt->id}/ergebnisse/screening");
 
-    public function test_md_viewer_returns_404_for_missing_files(): void
-    {
-        $owner = User::factory()->withoutTwoFactor()->create();
-        $projekt = Projekt::factory()->create(['user_id' => $owner->id]);
+    $response->assertStatus(404);
+});
 
-        $response = $this->actingAs($owner)
-            ->get("/recherche/{$projekt->id}/ergebnisse/screening");
+test('md viewer handles multiple markdown files', function () {
+    Storage::disk('local')->put(
+        "recherche/{$this->projekt->id}/screening/report.md",
+        "# Screening Report\n\nFirst report."
+    );
+    Storage::disk('local')->put(
+        "recherche/{$this->projekt->id}/screening/summary.md",
+        "# Summary\n\nSecond summary."
+    );
+    Storage::disk('local')->put(
+        "recherche/{$this->projekt->id}/screening/data.txt",
+        "Some text file"
+    );
 
-        $response->assertStatus(404);
-    }
+    $response = $this->actingAs($this->owner)
+        ->get("/recherche/{$this->projekt->id}/ergebnisse/screening");
 
-    public function test_md_viewer_handles_multiple_markdown_files(): void
-    {
-        $owner = User::factory()->withoutTwoFactor()->create();
-        $projekt = Projekt::factory()->create(['user_id' => $owner->id]);
+    $response->assertStatus(200);
+    $response->assertSee('<h1>Screening Report</h1>', false);
+    $response->assertSee('First report.');
+    $response->assertSee('<h1>Summary</h1>', false);
+    $response->assertSee('Second summary.');
+    $response->assertDontSee('Some text file');
+});
 
-        // Don't use fake storage - use real storage
-        $dir = storage_path("app/recherche/{$projekt->id}/screening");
-        @mkdir($dir, 0755, true);
-        file_put_contents("$dir/report.md", "# Screening Report\n\nFirst report.");
-        file_put_contents("$dir/summary.md", "# Summary\n\nSecond summary.");
-        file_put_contents("$dir/data.txt", "Some text file");
+test('md viewer rejects invalid phases', function () {
+    $response = $this->actingAs($this->owner)
+        ->get("/recherche/{$this->projekt->id}/ergebnisse/invalid-phase");
 
-        try {
-            $response = $this->actingAs($owner)
-                ->get("/recherche/{$projekt->id}/ergebnisse/screening");
-
-            $response->assertStatus(200);
-            $response->assertSee('<h1>Screening Report</h1>');
-            $response->assertSee('First report.');
-            $response->assertSee('<h1>Summary</h1>');
-            $response->assertSee('Second summary.');
-            $response->assertDontSee('Some text file');
-        } finally {
-            // Cleanup
-            @unlink("$dir/report.md");
-            @unlink("$dir/summary.md");
-            @unlink("$dir/data.txt");
-            @rmdir($dir);
-            @rmdir(dirname($dir));
-        }
-    }
-}
+    $response->assertStatus(404);
+});


### PR DESCRIPTION
## Beschreibung

Implementiert Issue #136 mit Webhook-Handler, Markdown-Viewer und Integrationstests. Alle Tests grün.

Setzt eine End-to-End-Pipeline um, die Agent-Ergebnisse als Markdown-Artefakte über einen signierten Webhook empfängt, persistiert und über einen neuen Volt-basierten Viewer im Recherche-Bereich anzeigt.

**Neue Features:**
- Webhook-Endpoint `/api/webhooks/langdock/agent-result` mit HMAC-Signaturprüfung, speichert `md_files` pro Projekt und Phase und legt strukturierte Ergebnis-Metadaten in `phase_agent_results` ab.
- Volt-Viewer unter `/recherche/{projekt}/ergebnisse/{phase}` rendert gespeicherte Markdown-Reports mit Policy-basierter Zugriffskontrolle.

**Sicherheitshärtung (basierend auf Code-Review-Feedback):**
- Striktes Phasen-Whitelist im Viewer (`recherche`, `screening`, `auswertung`) — ungültige Phase-Parameter werden mit 404 abgebrochen (verhindert Path-Traversal).
- XSS-Sanitierung beim Markdown-Rendering: `Str::markdown()` nutzt jetzt `html_input: 'strip'` und `allow_unsafe_links: false`.
- `validateFilePath()` im Webhook-Controller blockiert `..`, absolute Pfade, Backslashes, Doppelslashes und nicht-`.md`-Erweiterungen (HTTP 400 bei ungültigem Pfad).
- Unbenutzter Import `use Illuminate\Http\Response` entfernt.

**Enhancements:**
- `PhaseAgentResult` um `phase` (lesbar) und `result_data` (strukturiert) erweitert, neben dem Legacy-`phase_nr`.
- `local`-Disk-Root angepasst für Lesen/Schreiben von Agent-generierten Markdown-Dateien.
- Langdock-Webhook-Secret in `config/services.php` konfiguriert.

**Build:**
- `LANGDOCK_WEBHOOK_SECRET` als phpunit-Umgebungsvariable gesetzt.

**Tests:**
- Alle drei Testdateien von PHPUnit-Klassenstil auf **Pest-Syntax** umgestellt (Projektkonvention).
- `Storage::fake('local')` statt direkter `storage_path()`-Datei-IO für zuverlässige, parallelisierbare Tests.
- `assertSee(..., false)` für rohes HTML-Output korrekt gesetzt.
- 13 Tests gesamt: 5 Webhook-Tests, 5 Viewer-Tests, 3 Integrationstests (inkl. Phasen-Whitelist-Test).

## Änderungstyp

- [ ] Bug-Fix
- [x] Feature
- [ ] Refactoring
- [ ] Dokumentation
- [ ] CI / Infrastruktur

## Checkliste

- [x] Code folgt den bestehenden Konventionen (Pint-Lint bestanden)
- [x] Tests geschrieben / aktualisiert und grün
- [x] Keine neuen Compiler-/Linter-Warnungen
- [ ] Datenbank-Migration enthalten? → Rollback getestet
- [ ] Breaking Change? → In Beschreibung dokumentiert
- [ ] Deploy-Hinweis nötig? → Unten ergänzt

## Deploy-Hinweise

`LANGDOCK_WEBHOOK_SECRET` muss in der `.env` gesetzt sein (wird für HMAC-Signaturprüfung des Webhooks benötigt).