### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/oaipmh.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/oaipmh.py
@@ -9,6 +9,7 @@ OAI-PMH, such as BASE and CiteSeerX.
 
 from typing import List, Optional, Dict, Any
 from datetime import datetime
+from urllib.parse import urlparse
 import requests
 import xml.etree.ElementTree as ET
 import time
@@ -224,8 +225,13 @@ class OAIPMHSearcher(PaperSource):
             doi = ''
             identifier_elems = dc_root.findall(f'{{{DC_NS}}}identifier') or dc_root.findall('identifier')
             for elem in identifier_elems:
-                if elem.text and 'doi.org' in elem.text.lower():
-                    doi = elem.text
+                if not elem.text:
+                    continue
+                candidate = elem.text.strip()
+                parsed = urlparse(candidate)
+                host = (parsed.hostname or '').lower()
+                if parsed.scheme in ('http', 'https') and host in ('doi.org', 'www.doi.org'):
+                    doi = candidate
                     break
 
             # If no DOI found, try to extract from text


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/10](https://github.com/Nileneb/app.linn.games/security/code-scanning/10)

The best fix is to stop using substring matching and instead parse identifier values as URLs, then validate the parsed hostname exactly (or with strict subdomain logic). In this code, for DOI URL detection, accept only identifiers whose parsed hostname is exactly `doi.org` or `www.doi.org` (common variant), and only when scheme is `http`/`https`.

In `paper-search-mcp/paper_search_mcp/academic_platforms/oaipmh.py`:
- Add `urlparse` import from `urllib.parse`.
- Replace the loop condition on line 227 with URL parsing logic:
  - Trim text.
  - Parse with `urlparse`.
  - Check scheme is HTTP(S).
  - Check hostname is in an allowlist (`doi.org`, `www.doi.org`).
  - If valid, set `doi` and break.

This preserves existing behavior intent (detect DOI URLs in identifiers) while eliminating unsafe substring acceptance.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent unsafe DOI detection by replacing substring matching on identifier text with strict URL parsing and hostname validation for doi.org URLs.