### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/semantic.py
@@ -5,6 +5,7 @@ import requests
 from bs4 import BeautifulSoup
 import time
 import random
+from urllib.parse import urlparse
 from ..paper import Paper
 from ..utils import extract_doi
 from .base import PaperSource
@@ -66,11 +67,19 @@ class SemanticSearcher(PaperSource):
         if not all_urls:
             return ""
         
-        doi_urls = [url for url in all_urls if 'doi.org' in url]
+        def _host_matches(url: str, domain: str) -> bool:
+            try:
+                host = (urlparse(url).hostname or "").lower()
+            except ValueError:
+                return False
+            domain = domain.lower()
+            return host == domain or host.endswith(f".{domain}")
+
+        doi_urls = [url for url in all_urls if _host_matches(url, "doi.org")]
         if doi_urls:
             return doi_urls[0]
         
-        non_unpaywall_urls = [url for url in all_urls if 'unpaywall.org' not in url]
+        non_unpaywall_urls = [url for url in all_urls if not _host_matches(url, "unpaywall.org")]
         if non_unpaywall_urls:
             url = non_unpaywall_urls[0]
             if 'arxiv.org/abs/' in url:


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/11](https://github.com/Nileneb/app.linn.games/security/code-scanning/11)

Use URL parsing and hostname-based checks instead of substring checks on the full URL string.

Best fix here:
- In `paper-search-mcp/paper_search_mcp/academic_platforms/semantic.py`, add `urlparse` import from `urllib.parse`.
- In `_extract_url_from_disclaimer`, replace:
  - `doi_urls = [url for url in all_urls if 'doi.org' in url]`
  - `non_unpaywall_urls = [url for url in all_urls if 'unpaywall.org' not in url]`
- With hostname-aware helpers that:
  - parse each URL,
  - normalize hostname to lowercase,
  - match exact domain or subdomain safely (`host == domain or host.endswith("." + domain)`).

This preserves behavior intent (prefer DOI, avoid Unpaywall) while removing incomplete substring sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incomplete URL substring sanitization by using parsed hostnames to identify DOI and Unpaywall domains when extracting disclaimer URLs.