### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/base_search.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/base_search.py
@@ -11,6 +11,7 @@ Documentation: https://www.base-search.net/about/en/about_sources_date.php
 
 from typing import List, Optional, Dict, Any
 import logging
+from urllib.parse import urlparse
 from .oaipmh import OAIPMHSearcher
 from ..paper import Paper
 
@@ -127,8 +128,11 @@ class BASESearcher(OAIPMHSearcher):
                     paper.extra['base_id'] = ident_text
                 elif 'urn:nbn:' in ident_text:
                     paper.extra['urn'] = ident_text
-                elif 'hdl.handle.net' in ident_text:
-                    paper.extra['handle'] = ident_text
+                else:
+                    parsed = urlparse(ident_elem.text)
+                    host = (parsed.hostname or "").lower()
+                    if host == 'hdl.handle.net':
+                        paper.extra['handle'] = ident_text
 
         # Extract rights information
         rights_elems = dc_root.findall('.//{http://purl.org/dc/elements/1.1/}rights') or \


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/7](https://github.com/Nileneb/app.linn.games/security/code-scanning/7)

Use URL parsing (`urllib.parse.urlparse`) and validate the hostname instead of substring matching.

Best fix in this file:
- Add `urlparse` import near existing imports.
- In `_enrich_paper_from_oai`, keep lowercasing for non-URL checks (`base-search.net`, `urn:nbn:`), but replace the handle detection branch with:
  - parse `ident_elem.text`
  - extract normalized hostname
  - accept only exact `hdl.handle.net` host (optionally tolerant of case)
This preserves behavior (still detects handle identifiers) while removing unsafe substring logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix unsafe handle URL detection by requiring the parsed hostname to exactly match hdl.handle.net instead of relying on substring checks.