### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/base_search.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/base_search.py
@@ -11,6 +11,7 @@ Documentation: https://www.base-search.net/about/en/about_sources_date.php
 
 from typing import List, Optional, Dict, Any
 import logging
+from urllib.parse import urlparse
 from .oaipmh import OAIPMHSearcher
 from ..paper import Paper
 
@@ -123,7 +124,9 @@ class BASESearcher(OAIPMHSearcher):
         for ident_elem in identifiers:
             if ident_elem.text:
                 ident_text = ident_elem.text.lower()
-                if 'base-search.net' in ident_text:
+                parsed_ident = urlparse(ident_elem.text)
+                host = parsed_ident.hostname.lower() if parsed_ident.hostname else ""
+                if host == "base-search.net" or host.endswith(".base-search.net"):
                     paper.extra['base_id'] = ident_text
                 elif 'urn:nbn:' in ident_text:
                     paper.extra['urn'] = ident_text


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/6](https://github.com/Nileneb/app.linn.games/security/code-scanning/6)

The correct fix is to parse identifier values as URLs and validate the hostname explicitly, rather than checking whether a domain string appears anywhere in the text.

Best single fix in `paper-search-mcp/paper_search_mcp/academic_platforms/base_search.py`:
- Add `urlparse` import from `urllib.parse`.
- In `_enrich_paper_from_oai`, replace the substring check with:
  - Parse `ident_elem.text` via `urlparse`.
  - Read `hostname` safely.
  - Accept only exact host `base-search.net` or subdomains ending with `.base-search.net`.
- Keep existing behavior for URN/handle detection and stored value semantics (still storing lowered text in `base_id`).

This preserves functionality while eliminating bypass-prone substring matching.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Validate OAI identifier URLs by parsing the hostname and only accepting exact or subdomain matches for base-search.net instead of relying on substring checks.