### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/citeseerx.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/citeseerx.py
@@ -5,7 +5,7 @@ import requests
 import logging
 import json
 import xml.etree.ElementTree as ET
-from urllib.parse import quote, urlencode
+from urllib.parse import quote, urlencode, urlparse
 from requests.exceptions import SSLError
 import urllib3
 
@@ -55,7 +55,8 @@ class CiteSeerXSearcher(PaperSource):
 
         # If the endpoint redirected to the Wayback Machine the original host
         # is no longer serving live API responses; treat this as unavailable.
-        if "web.archive.org" in resp.url:
+        host = (urlparse(resp.url).hostname or "").lower()
+        if host == "web.archive.org" or host.endswith(".web.archive.org"):
             raise requests.HTTPError(
                 f"CiteSeerX endpoint redirected to web archive ({resp.url}); "
                 "the live API is currently unavailable.",


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/8](https://github.com/Nileneb/app.linn.games/security/code-scanning/8)

The fix is to parse `resp.url` and compare only the hostname, not the full URL string.

Best approach in this file:
- Add `urlparse` import from `urllib.parse`.
- In `_get`, replace the substring check with:
  - `host = (urlparse(resp.url).hostname or "").lower()`
  - match `host == "web.archive.org"` or subdomains via `host.endswith(".web.archive.org")`
- Keep behavior otherwise unchanged (still raises the same `HTTPError` message when archive redirect is detected).

This change is localized to `paper-search-mcp/paper_search_mcp/academic_platforms/citeseerx.py` around the import line and the check in `_get` around current lines 56–63.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Avoid false positives and incomplete sanitization by checking the response URL’s hostname for web.archive.org (including subdomains) instead of using a raw substring match.