### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/dblp.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/dblp.py
@@ -5,6 +5,7 @@ import requests
 import logging
 import xml.etree.ElementTree as ET
 import time
+from urllib.parse import urlparse
 from bs4 import BeautifulSoup
 
 from ..paper import Paper
@@ -257,9 +258,13 @@ class DBLPSearcher(PaperSource):
             ee_elems = info.findall('ee')
             for ee_elem in ee_elems:
                 ee_text = ee_elem.text.strip() if ee_elem.text else ""
-                if 'doi.org' in ee_text:
-                    doi = ee_text.split('doi.org/')[-1]
-                    break
+                parsed_ee = urlparse(ee_text)
+                ee_host = (parsed_ee.hostname or "").lower()
+                if ee_host in {"doi.org", "dx.doi.org"}:
+                    extracted_doi = parsed_ee.path.lstrip("/")
+                    if extracted_doi:
+                        doi = extracted_doi
+                        break
                 elif ee_text.startswith('10.'):
                     doi = ee_text
                     break


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/9](https://github.com/Nileneb/app.linn.games/security/code-scanning/9)

To fix this safely, parse `ee_text` as a URL and validate the **hostname** instead of searching for `'doi.org'` as a substring. Then extract DOI from the URL path only when the host is exactly `doi.org` (or a known DOI short host like `dx.doi.org`), and keep the existing direct DOI fallback (`startswith('10.')`) for non-URL DOI strings.

Best concrete fix in `paper-search-mcp/paper_search_mcp/academic_platforms/dblp.py`:

1. Add `urlparse` import from `urllib.parse`.
2. In `_parse_dblp_hit`, replace:
   - `if 'doi.org' in ee_text: doi = ee_text.split('doi.org/')[-1]`
   with:
   - Parse URL via `parsed = urlparse(ee_text)`.
   - Get normalized host: `(parsed.hostname or "").lower()`.
   - If host is in `{"doi.org", "dx.doi.org"}`, derive DOI from `parsed.path.lstrip('/')`.
   - Accept only non-empty extracted DOI.
3. Keep `elif ee_text.startswith('10.')` branch unchanged to preserve behavior for raw DOI values.

This preserves existing functionality while eliminating the unsafe substring-based host check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent incomplete URL substring sanitization when detecting doi.org links by switching to hostname-based URL parsing before DOI extraction.