### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/paper-search-mcp/paper_search_mcp/academic_platforms/semantic.py
+++ b/paper-search-mcp/paper_search_mcp/academic_platforms/semantic.py
@@ -67,7 +67,11 @@ class SemanticSearcher(PaperSource):
         if not all_urls:
             return ""
 
-        doi_urls = [url for url in all_urls if "doi.org" in url]
+        doi_urls = [
+            url
+            for url in all_urls
+            if (urlparse(url).hostname or "").lower() == "doi.org"
+        ]
         if doi_urls:
             return doi_urls[0]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Nileneb/app.linn.games/security/code-scanning/12](https://github.com/Nileneb/app.linn.games/security/code-scanning/12)

Use `urllib.parse.urlparse` (already imported) to parse each URL and compare the **hostname** exactly against the trusted domain (`doi.org`) instead of using substring matching on the full URL.

Best minimal fix in `paper-search-mcp/paper_search_mcp/academic_platforms/semantic.py`:
- Replace line 70 logic with a hostname-based predicate.
- Normalize host to lowercase and handle missing host safely.
- Keep existing behavior (first DOI URL is preferred) unchanged.

No new imports are needed since `urlparse` is already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent insecure or incorrect DOI URL detection by matching URLs with an exact doi.org hostname rather than substring-based checks.